### PR TITLE
Only create `navigator.analytics` on supported platforms

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,11 +15,12 @@
   <keywords>cordova,analytics</keywords>
   <repo>https://github.com/cmackay/google-analytics-plugin.git</repo>
 
-  <js-module src="www/analytics.js" name="GoogleAnalytics">
-    <clobbers target="navigator.analytics" />
-  </js-module>
+  
 
   <platform name="ios">
+    <js-module src="www/analytics.js" name="GoogleAnalytics">
+      <clobbers target="navigator.analytics" />
+    </js-module>
     <config-file target="config.xml" parent="/*">
       <feature name="GoogleAnalytics">
         <param name="ios-package" value="GoogleAnalyticsPlugin" />
@@ -47,6 +48,9 @@
   </platform>
 
   <platform name="android">
+    <js-module src="www/analytics.js" name="GoogleAnalytics">
+      <clobbers target="navigator.analytics" />
+    </js-module>
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GoogleAnalytics">
         <param name="android-package" value="com.cmackay.plugins.googleanalytics.GoogleAnalyticsPlugin" />


### PR DESCRIPTION
By not creating `navigator.analytics` in a global `<js-module>`, `navigator.analytics` can be checked against and an appropriate fallback can be used.

This is particularly useful for `cordova-browser` users.
